### PR TITLE
Fix: Back button press during content (not ad) will return to DetailsFlow

### DIFF
--- a/components/ContentFlow.xml
+++ b/components/ContentFlow.xml
@@ -8,7 +8,7 @@
 -->
 <component
     name="ContentFlow"
-    extends="Group">
+    extends="BaseFlow">
 
     <script
         type="text/brightscript"

--- a/components/DetailsFlow.brs
+++ b/components/DetailsFlow.brs
@@ -20,9 +20,19 @@ sub init()
     m.playButton = m.top.FindNode("playButton")
     m.playButton.ObserveField("buttonSelected", "onPlayButtonSelected")
 
-    m.imagesLoaded = 0
-    m.top.FindNode("backgroundImage").ObserveField("loadStatus", "onImageLoaded")
-    m.top.FindNode("backgroundImage2").ObserveField("loadStatus", "onImageLoaded")
+    m.numImagesLoading = 0
+    bgPoster = m.top.FindNode("backgroundImage")
+    if bgPoster.loadStatus = "loading" then
+        bgPoster.ObserveField("loadStatus", "onImageLoaded")
+        m.numImagesLoading += 1
+    end if
+    bgPoster2 = m.top.FindNode("backgroundImage")
+    if bgPoster2.loadStatus = "loading" then
+        bgPoster2.ObserveField("loadStatus", "onImageLoaded")
+        m.numImagesLoading += 1
+    end if
+
+    if m.numImagesLoading = 0 then m.top.visible = true
 
     if m.global.streamInfo = invalid then return
     streamInfo = ParseJson(m.global.streamInfo)[0]
@@ -58,8 +68,8 @@ end sub
 sub onImageLoaded(event as Object)
     data = event.GetData()
     ? "TRUE[X] >>> DetailsFlow::onImageLoaded(event=";data;")"
-    if data = "ready" or data = "failed" then m.imagesLoaded = m.imagesLoaded + 1
-    if m.imagesLoaded > 1 then m.rootLayout.visible = true
+    if data <> "loading" then m.numImagesLoading -= 1
+    if m.numImagesLoading = 0 then m.rootLayout.visible = true
 end sub
 
 '-----------------------------------------------------------------------

--- a/components/MainScene.brs
+++ b/components/MainScene.brs
@@ -34,13 +34,17 @@ end sub
 ' Callback triggered by Flow's when their m.top.event field is set.
 '
 ' Supported triggers:
-'   * "playButtonSelected" - transition to ContentFlow
+'   * playButtonSelected - transition to ContentFlow
+'   * streamInfoReceived - populates global streamInfo field
+'   * cancelStream - transition to DetailsFlow
 '
 ' Params:
 '   * event as roSGNodeEvent - contains the Flow event data
 '-------------------------------------------------------------------
-sub onFlowEvent(event as Object)
+sub onFlowEvent(event as object)
     data = event.GetData()
+    ? "TRUE[X] >>> MainScene::onFlowEvent(trigger=";data.trigger;")"
+
     if data.trigger = "playButtonSelected" then
         showFlow("ContentFlow")
     else if data.trigger = "cancelStream" then
@@ -123,6 +127,8 @@ sub removeCurrentFlow()
 
     if m.currentFlow <> invalid then
         m.currentFlow.UnobserveField("event")
+        m.currentFlow.visible = false
+        m.currentFlow.SetFocus(false)
         m.rootLayout.RemoveChild(m.currentFlow)
         m.currentFlow = invalid
     end if


### PR DESCRIPTION
* `ContentFlow` now stops the video player and background task when cancelling stream
* `DetailsFlow` only has to listen for image load events the first time it's loaded, subsequent instances will have the image waiting in cache
* Using `resume` control on video player instead of `play` so the video doesn't restart