### PR TITLE
FIX: ad skipping and opt-out in ref app

### DIFF
--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -134,7 +134,8 @@ sub onTruexEvent(event as object)
         '
 
         ' user has earned credit for the engagement, move content past ad break (but don't resume playback)
-        m.videoPlayer.seek = m.currentAdBreak.timeOffset + m.currentAdBreak.duration
+        ? "TRUE[X] >>> ContentFlow::onTruexEvent, ad skipping, current position: " ; m.videoPlayer.position ; " duration of rest of break: " ; m.currentAdBreak.duration
+        m.videoPlayer.seek = m.videoPlayer.position + m.currentAdBreak.duration
     else if data.type = "adStarted" then
         ' this event is triggered when a true[X] engagement as started
         ' that means the user was presented with a Choice Card and opted into an interactive ad
@@ -144,7 +145,6 @@ sub onTruexEvent(event as object)
     else if data.type = "optOut" then
         ' this event is triggered when a user decides not to view a true[X] interactive ad
         ' that means the user was presented with a Choice Card and opted to watch standard video ads
-        m.videoPlayer.control = "resume"
     else if data.type = "adCompleted" then
         ' this event is triggered when TruexAdRenderer is done presenting the ad
 
@@ -199,15 +199,17 @@ sub onTruexAdDataReceived(event as object)
     decodedData = event.getData()
     if decodedData = invalid then return
 
+    ? "TRUE[X] >>> ContentFlow::onTruexAdDataReceived(), decodedData: " ; decodedData
+
     '
     ' [4]
     '
-    ? "TRUE[X] >>> ContentFlow::onTruexAdDataReceived() - seeking video position past placeholder ad and pausing..."
+    ? "TRUE[X] >>> ContentFlow::onTruexAdDataReceived() - seeking video position past placeholder ad and pausing..., position: " ; m.videoPlayer.position ; " placeholderDuration: " ; decodedData.placeholderDuration
 
     ' pause the stream, which is currently playing a video ad
     m.videoPlayer.control = "pause"
     ' seek past the True[X] placeholder video ad
-    m.videoPlayer.seek = m.videoPlayer.position + decodedData.currentAdBreak.duration
+    m.videoPlayer.seek = m.videoPlayer.position + decodedData.placeholderDuration
     m.currentAdBreak = decodedData.currentAdBreak
 
     '

--- a/components/ImaSdkTask.brs
+++ b/components/ImaSdkTask.brs
@@ -67,7 +67,7 @@ end sub
 '     wrappers: []
 ' }
 sub onStreamStarted(ad as object)
-    ? "TRUE[X] >>> ImaSdkTask::onStreamStarted()"
+    ? "TRUE[X] >>> ImaSdkTask::onStreamStarted(), ad: ";ad
 
     '
     ' [2]
@@ -104,7 +104,15 @@ sub onStreamStarted(ad as object)
             ? "TRUE[X] >>> ImaSdkTask::onStreamStarted() - could not decode true[X] companion ad data, aborting..."
         else
             ' add the current ad break info to the data object so ContentFlow can access
+            ' ensuring the placeholder video duration is subtracted out so we don't seek past the end of the pod
+            ' and into content when doing an ad akip
+            if ad.duration <> invalid then 
+                decodedData.placeholderDuration = ad.duration 
+            else 
+                decodedData.placeholderDuration = 30 
+            end if
             decodedData.currentAdBreak = m.top.currentAdBreak
+            decodedData.currentAdBreak.duration = m.top.currentAdBreak.duration - ad.duration
             ? "TRUE[X] >>> ImaSdkTask::onStreamStarted() - decodedData=";FormatJson(decodedData)
 
             ' set true[X] ad data object for ContentFlow to handle on main thread


### PR DESCRIPTION
There are a few things going on here:

We need to identify the duration of the trueX placeholder / blank video to skip over as part of the setup for interactive ads. Currently using the duration of the overall pod.

When completing an ad, the remainder of the ad break needs to be skipped, which corresponds to the ad break duration coming from Google, minus the aforementioned placeholder ad.

This fixes opt-in + complete ad, and opt-out. Auto-advance opt-out is broken because of player management issues (separate).