### PR TITLE
Fix: Video stream seek behavior

### DIFF
--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -32,7 +32,7 @@ end sub
 '-------------------------------------------
 function onKeyEvent(key as string, press as boolean) as boolean
     ? "TRUE[X] >>> ContentFlow::onKeyEvent(key=";key;"press=";press.ToStr();")"
-    if not m.sdkLoadTask.adPlaying and press and key = "back" then
+    if press and key = "back" and m.adRenderer = invalid then
         ? "TRUE[X] >>> ContentFlow::onKeyEvent() - back pressed while content is playing, requesting stream cancel..."
         tearDown()
         m.top.event = { trigger: "cancelStream" }

--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -134,17 +134,17 @@ sub onTruexEvent(event as object)
         '
 
         ' user has earned credit for the engagement, move content past ad break (but don't resume playback)
+        m.videoPlayer.enableUi = true
+        m.videoPlayer.enableTrickPlay = true
         m.videoPlayer.seek = m.currentAdBreak.timeOffset + m.currentAdBreak.duration
     else if data.type = "adStarted" then
         ' this event is triggered when a true[X] engagement as started
         ' that means the user was presented with a Choice Card and opted into an interactive ad
-        m.videoPlayer.control = "pause"
     else if data.type = "adFetchCompleted" then
         ' this event is triggered when TruexAdRenderer receives a response to an ad fetch request
     else if data.type = "optOut" then
         ' this event is triggered when a user decides not to view a true[X] interactive ad
         ' that means the user was presented with a Choice Card and opted to watch standard video ads
-        m.videoPlayer.control = "resume"
     else if data.type = "adCompleted" then
         ' this event is triggered when TruexAdRenderer is done presenting the ad
 
@@ -154,10 +154,12 @@ sub onTruexEvent(event as object)
 
         ' if the user earned credit (via "adFreePod") their content will already be seeked past the ad break
         ' if the user has not earned credit their content will resume at the beginning of the ad break
-        m.adRenderer.visible = false
         m.adRenderer.SetFocus(false)
-        m.top.SetFocus(true)
-        m.videoPlayer.control = "resume"
+        m.top.removeChild(m.adRenderer)
+        m.adRenderer.visible = false
+        m.videoPlayer.SetFocus(true)
+        m.videoPlayer.control = "play"
+        m.videoPlayer.seek = m.videoPositionAtAdBreakPause + 30
     else if data.type = "adError" then
         ' this event is triggered whenever TruexAdRenderer encounters an error
         ' usually this means the video stream should continue with normal video ads
@@ -206,8 +208,6 @@ sub onTruexAdDataReceived(event as object)
 
     ' pause the stream, which is currently playing a video ad
     m.videoPlayer.control = "pause"
-    ' seek past the True[X] placeholder video ad
-    m.videoPlayer.seek = m.videoPlayer.position + decodedData.currentAdBreak.duration
     m.currentAdBreak = decodedData.currentAdBreak
 
     '

--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -136,8 +136,7 @@ sub onTruexEvent(event as object)
         ' user has earned credit for the engagement, set seek duration to skip the entire ad break
         m.streamSeekDuration = m.currentAdBreak.duration
     else if data.type = "adStarted" then
-        ' this event is triggered when a true[X] engagement as started
-        ' that means the user was presented with a Choice Card and opted into an interactive ad
+        ' this event is triggered when the true[X] Choice Card is presented to the user
     else if data.type = "adFetchCompleted" then
         ' this event is triggered when TruexAdRenderer receives a response to an ad fetch request
     else if data.type = "optOut" then

--- a/components/ImaSdkTask.brs
+++ b/components/ImaSdkTask.brs
@@ -105,6 +105,8 @@ sub onStreamStarted(ad as object)
         else
             ' add the current ad break info to the data object so ContentFlow can access
             decodedData.currentAdBreak = m.top.currentAdBreak
+            if ad.duration = invalid then ad.duration = 30
+            decodedData.truexAdDuration = ad.duration
             ? "TRUE[X] >>> ImaSdkTask::onStreamStarted() - decodedData=";FormatJson(decodedData)
 
             ' set true[X] ad data object for ContentFlow to handle on main thread
@@ -203,6 +205,7 @@ sub setupVideoPlayer()
         ? "TRUE[X] >>> ImaSdkTask::adBreakStarted(adBreakInfo=";adBreakInfo;")"
         m.top.currentAdBreak = adBreakInfo
         m.top.adPlaying = true
+        m.top.video.enableUi = false
         m.top.video.enableTrickPlay = false
     end function
 


### PR DESCRIPTION
This PR introduces changes to `ContentView` that allow it to adjust the video stream seek position based on TAR events.

* Seeks past the true[X] placeholder video in all scenarios
* Seeks past the entire ad break when `adFreePod` is earned
* `Opt-in->Complete` | `Opt-in->Opt-out` | `Opt-out` | `AA Opt-out` scenarios tested and behave as expected, either resuming the video stream at the start of the video ads or at the start of the content

One other minor change introduced is allowing `Back` presses to cancel the stream during video ads as well as during the content. Previously `Back` presses were ignored during the ad break.

Note: With this PR I don't think we need to merge #9 as it solves the same issues (plus more).