### PR TITLE
Feature: Snapback when seeking past ad pods

### DIFF
--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -32,7 +32,7 @@ end sub
 '-------------------------------------------
 function onKeyEvent(key as string, press as boolean) as boolean
     ? "TRUE[X] >>> ContentFlow::onKeyEvent(key=";key;"press=";press.ToStr();")"
-    if not m.sdkLoadTask.adPlaying and press and key = "back" then
+    if press and key = "back" and m.adRenderer = invalid then
         ? "TRUE[X] >>> ContentFlow::onKeyEvent() - back pressed while content is playing, requesting stream cancel..."
         tearDown()
         m.top.event = { trigger: "cancelStream" }

--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -134,17 +134,17 @@ sub onTruexEvent(event as object)
         '
 
         ' user has earned credit for the engagement, move content past ad break (but don't resume playback)
+        m.videoPlayer.enableUi = true
+        m.videoPlayer.enableTrickPlay = true
         m.videoPlayer.seek = m.currentAdBreak.timeOffset + m.currentAdBreak.duration
     else if data.type = "adStarted" then
         ' this event is triggered when a true[X] engagement as started
         ' that means the user was presented with a Choice Card and opted into an interactive ad
-        m.videoPlayer.control = "pause"
     else if data.type = "adFetchCompleted" then
         ' this event is triggered when TruexAdRenderer receives a response to an ad fetch request
     else if data.type = "optOut" then
         ' this event is triggered when a user decides not to view a true[X] interactive ad
         ' that means the user was presented with a Choice Card and opted to watch standard video ads
-        m.videoPlayer.control = "resume"
     else if data.type = "adCompleted" then
         ' this event is triggered when TruexAdRenderer is done presenting the ad
 
@@ -154,10 +154,12 @@ sub onTruexEvent(event as object)
 
         ' if the user earned credit (via "adFreePod") their content will already be seeked past the ad break
         ' if the user has not earned credit their content will resume at the beginning of the ad break
-        m.adRenderer.visible = false
         m.adRenderer.SetFocus(false)
-        m.top.SetFocus(true)
-        m.videoPlayer.control = "resume"
+        m.top.removeChild(m.adRenderer)
+        m.adRenderer.visible = false
+        m.videoPlayer.SetFocus(true)
+        m.videoPlayer.control = "play"
+        m.videoPlayer.seek = m.videoPositionAtAdBreakPause + 30
     else if data.type = "adError" then
         ' this event is triggered whenever TruexAdRenderer encounters an error
         ' usually this means the video stream should continue with normal video ads
@@ -206,8 +208,6 @@ sub onTruexAdDataReceived(event as object)
 
     ' pause the stream, which is currently playing a video ad
     m.videoPlayer.control = "pause"
-    ' seek past the True[X] placeholder video ad
-    m.videoPlayer.seek = m.videoPlayer.position + decodedData.currentAdBreak.duration
     m.currentAdBreak = decodedData.currentAdBreak
 
     '

--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -136,8 +136,7 @@ sub onTruexEvent(event as object)
         ' user has earned credit for the engagement, set seek duration to skip the entire ad break
         m.streamSeekDuration = m.currentAdBreak.duration
     else if data.type = "adStarted" then
-        ' this event is triggered when a true[X] engagement as started
-        ' that means the user was presented with a Choice Card and opted into an interactive ad
+        ' this event is triggered when the true[X] Choice Card is presented to the user
     else if data.type = "adFetchCompleted" then
         ' this event is triggered when TruexAdRenderer receives a response to an ad fetch request
     else if data.type = "optOut" then

--- a/components/ImaSdkTask.brs
+++ b/components/ImaSdkTask.brs
@@ -53,7 +53,6 @@ sub runLoop()
 
         m.streamManager.onMessage(msg)
 
-        currentContentTime = m.streamManager.getContentTime(m.top.video.position * 1000) / 1000
         currentStreamTime = m.top.video.position
         ' 2s is the seek threshold for triggering a snapback
         if Abs(currentStreamTime - m.lastVideoTime) > 2 then

--- a/components/ImaSdkTask.brs
+++ b/components/ImaSdkTask.brs
@@ -43,6 +43,9 @@ sub runLoop()
         m.top.video.ObserveField(field, m.port)
     end for
 
+    ' track last video position to support snapback
+    m.lastVideoTime = m.top.video.position
+
     while true
         msg = Wait(1000, m.port)
         ' continue running task until video is no longer available
@@ -50,10 +53,33 @@ sub runLoop()
 
         m.streamManager.onMessage(msg)
 
+        currentContentTime = m.streamManager.getContentTime(m.top.video.position * 1000) / 1000
+        currentStreamTime = m.top.video.position
+        ' 2s is the seek threshold for triggering a snapback
+        if Abs(currentStreamTime - m.lastVideoTime) > 2 then
+            if m.top.inSnapback then
+                m.top.inSnapback = false
+            else
+                onUserSeek(m.lastVideoTime, currentStreamTime)
+            end if
+        end if
+
         ' toggle trick play
-        m.top.video.enableTrickPlay = m.top.video.position > 3 and not m.top.adPlaying
+        m.top.video.enableTrickPlay = currentStreamTime > 3 and not m.top.adPlaying
+
+        m.lastVideoTime = currentStreamTime
     end while
     ? "TRUE[X] >>> Exiting ImaSdkTask::runLoop()"
+end sub
+
+sub onUserSeek(oldPosition as integer, newPosition as integer)
+    ? "TRUE[X] >>> ImaSdkTask::onUserSeek(oldPosition=";oldPosition;"newPosition=";newPosition")"
+    previousCuePoint = m.streamManager.getPreviousCuePoint(newPosition)
+    if previousCuePoint <> invalid and not previousCuePoint.hasPlayed then
+        m.top.video.seek = previousCuePoint.start + 1
+        m.top.snapbackTime = newPosition
+        m.top.inSnapback = true
+    end if
 end sub
 
 ' expected ad template = {
@@ -194,7 +220,6 @@ sub setupVideoPlayer()
 
     m.player.loadUrl = function(urlData)
         ? "TRUE[X] >>> ImaSdkTask::loadUrl(urlData=";urlData;")"
-        m.top.video.enableTrickPlay = false
         m.top.urlData = urlData
     end function
 
@@ -205,14 +230,15 @@ sub setupVideoPlayer()
         ? "TRUE[X] >>> ImaSdkTask::adBreakStarted(adBreakInfo=";adBreakInfo;")"
         m.top.currentAdBreak = adBreakInfo
         m.top.adPlaying = true
-        m.top.video.enableUi = false
-        m.top.video.enableTrickPlay = false
     end function
 
     m.player.adBreakEnded = function(adBreakInfo as Object)
         ? "TRUE[X] >>> ImaSdkTask::adBreakEnded(adBreakInfo=";adBreakInfo;")"
         m.top.adPlaying = false
-        m.top.video.enableTrickPlay = true
+        if m.top.snapbackTime > m.top.video.position then
+            m.top.video.seek = m.top.snapbackTime
+            m.top.snapbackTime = -1
+        end if
     end function
 end sub
 

--- a/components/ImaSdkTask.brs
+++ b/components/ImaSdkTask.brs
@@ -105,6 +105,8 @@ sub onStreamStarted(ad as object)
         else
             ' add the current ad break info to the data object so ContentFlow can access
             decodedData.currentAdBreak = m.top.currentAdBreak
+            if ad.duration = invalid then ad.duration = 30
+            decodedData.truexAdDuration = ad.duration
             ? "TRUE[X] >>> ImaSdkTask::onStreamStarted() - decodedData=";FormatJson(decodedData)
 
             ' set true[X] ad data object for ContentFlow to handle on main thread
@@ -203,6 +205,7 @@ sub setupVideoPlayer()
         ? "TRUE[X] >>> ImaSdkTask::adBreakStarted(adBreakInfo=";adBreakInfo;")"
         m.top.currentAdBreak = adBreakInfo
         m.top.adPlaying = true
+        m.top.video.enableUi = false
         m.top.video.enableTrickPlay = false
     end function
 

--- a/components/ImaSdkTask.xml
+++ b/components/ImaSdkTask.xml
@@ -40,6 +40,12 @@
         <!-- Set when user requests that the video stream be cancelled. Usually by pressing back at the Choice Card. -->
         <field id="userCancelStream" type="boolean"/>
 
+        <!-- Set when user is currently snapped back to an ad from trying to seek past it. -->
+        <field id="inSnapback" type="boolean" value="false"/>
+
+        <!-- Set when user is currently snapped back to an ad from trying to seek past it. -->
+        <field id="snapbackTime" type="integer" value="-1"/>
+
         <!-- Updated with true[X] ad companion data when found during an ad break. -->
         <field id="truexAdData" type="assocarray"/>
     </interface>


### PR DESCRIPTION
This PR introduces the [snapback](https://developers.google.com/interactive-media-ads/docs/sdks/roku/snapback) feature. Snapback prevents users from skipping ads when seeking the video stream past an ad pod.

How it works:
* User is watching content
* User clicks the seek bar to fast-forward the video to some time (**t1**) past the next ad pod
* **t1** is cached, the video position is then set to the beginning of the skipped ad pod
* When the ad break completes the video position is set to **t1**

Note: This branch is based on `issue/correct-truex-placeholder-seek-duration`. If #10 is merged before this PR make sure this PR merge target is set to `master`.