### PR TITLE
Fix: Play button focus toggles on directional key presses

### DIFF
--- a/components/DetailsFlow.brs
+++ b/components/DetailsFlow.brs
@@ -76,12 +76,14 @@ end sub
 ' Determines the next view element to focus from the given direction.
 '
 ' Params:
-'   * direction as String - the directional key (on the remote) pressed
+'   * direction as string - the directional key (on the remote) pressed
 '
 ' Return:
 '   true always
 '-----------------------------------------------------------------------
-function focusElement(direction as String) as Boolean
-    m.playButton.SetFocus(not m.playButton.HasFocus())
+function focusElement(direction as string) as boolean
+    playButtonFocus = m.playButton.HasFocus()
+    m.rootLayout.SetFocus(true)
+    m.playButton.SetFocus(not playButtonFocus)
     return true
 end function

--- a/components/DetailsFlow.xml
+++ b/components/DetailsFlow.xml
@@ -16,7 +16,8 @@
     <children>
         <Group
             id="baseFlowLayout"
-            visible="false">
+            visible="false"
+            focusable="true">
 
             <Poster
                 id="backgroundImage"

--- a/components/FetchStreamInfoTask.brs
+++ b/components/FetchStreamInfoTask.brs
@@ -46,7 +46,7 @@ sub requestStreamInfo()
                 m.top.streamInfo = response
             end if
         else
-            m.top.error = "Unrecognized event returned from AsyncGetToString(), event=" + event
+            m.top.error = "Unrecognized event returned from AsyncGetToString() - URI=" + m.top.uri
         end if
     else
         m.top.error = "httpRequest.AsyncGetToString() failed"


### PR DESCRIPTION
Was getting stuck after losing focus because key events weren't going to the `DetailsFlow` component.