### PR TITLE
Fix: Use consistent client ID to track users across sessions

### DIFF
--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -287,13 +287,19 @@ function determineVastConfigUrl(baseUrl as string, userId as string) as string
     if Left(baseUrl, 4) <> "http" then baseUrl = "https://" + baseUrl
 
     ' append URL parameters; network_user_id, stream_position, env[]
-    baseUrl = baseUrl + "&network_user_id=" + userId
+    baseUrl = baseUrl + "&network_user_id=" + getClientAdvertisingId()
     baseUrl = baseUrl + "&stream_position=" + getCurrentAdBreakSlotType()
     baseUrl = baseUrl + "&env%5B%5D=brightscript"
     baseUrl = baseUrl + "&env%5B%5D=layoutJSON"
 
     ? "TRUE[X] >>> ContentFlow::determineVastConfigUrl() - URL=";baseUrl
     return baseUrl
+end function
+
+function getClientAdvertisingId() as string
+    deviceInfo = CreateObject("roDeviceInfo")
+    if deviceInfo.IsRIDADisabled() then return "optOut"
+    return deviceInfo.GetRIDA()
 end function
 
 '-----------------------------------------------------------------------------------

--- a/components/DetailsFlow.xml
+++ b/components/DetailsFlow.xml
@@ -108,8 +108,7 @@
                     <Poster
                         id="episode1"
                         width="302"
-                        height="453"
-                        color="0xFFFFFFFF"/>
+                        height="453"/>
 
                     <Rectangle
                         id="episode2"

--- a/components/MainScene.brs
+++ b/components/MainScene.brs
@@ -17,11 +17,11 @@ sub init()
     ? "TRUE[X] >>> MainScene::init()"
 
     ' grab a reference to the root layout node, which will be the parent layout for all nodes
-    m.rootLayout = m.top.FindNode("rootLayout")
+    m.rootLayout = m.top.findNode("rootLayout")
 
     ' listen for Truex library load events
-    m.tarLibrary = m.top.FindNode("TruexAdRendererLib")
-    m.tarLibrary.ObserveField("loadStatus", "onTruexLibraryLoadStatusChanged")
+    m.tarLibrary = m.top.findNode("TruexAdRendererLib")
+    m.tarLibrary.observeField("loadStatus", "onTruexLibraryLoadStatusChanged")
 
     ' create/set global fields with Channel dimensions (m.global.channelWidth/channelHeight)
     setChannelWidthHeightFromRootScene()
@@ -50,7 +50,7 @@ sub onFlowEvent(event as object)
     else if data.trigger = "cancelStream" then
         showFlow("DetailsFlow")
     else if data.trigger = "streamInfoReceived" then
-        ensureGlobalStreamInfoField(data.streamInfo)
+        setGlobalField("streamInfo", data.streamInfo)
         if m.tarLibrary.loadStatus = "ready" or m.tarLibrary.loadStatus = "failed" then showFlow("DetailsFlow")
     end if
 end sub

--- a/components/MainScene.xml
+++ b/components/MainScene.xml
@@ -27,8 +27,7 @@
         <!-- ***** IMPORTANT ***** -->
         <ComponentLibrary
             id="TruexAdRendererLib"
-            uri="http://s3.amazonaws.com/ctv.truex.com/develop/TruexAdRenderer-Roku-v1.0.1.pkg"/>
-        <!-- TODO: update uri to something more permanent -->
+            uri="http://s3.amazonaws.com/ctv.truex.com/develop/TruexAdRenderer-Roku-v1.0.2.pkg"/>
 
         <!-- Used as parent layout for all Flow's. -->
         <Group

--- a/source/GlobalUtils.brs
+++ b/source/GlobalUtils.brs
@@ -18,7 +18,7 @@ sub setChannelWidthHeightFromRootScene()
     channelHeight = 1080
 
     ' overwrite defaults using Scene.currentDesignResolution values, if available
-    if m.top.GetScene() <> invalid then designResolution = m.top.GetScene().currentDesignResolution
+    if m.top.getScene() <> invalid then designResolution = m.top.getScene().currentDesignResolution
     if designResolution <> invalid then
         ? "TRUE[X] >>> GlobalUtils::setChannelWidthHeightFromRootScene() - setting from Scene's design resolution..."
         channelWidth = designResolution.width
@@ -26,31 +26,26 @@ sub setChannelWidthHeightFromRootScene()
     end if
 
     ' safely set the m.global channelWidth and channelHeight fields
-    ensureGlobalChannelResolutionField(channelWidth, channelHeight)
+    setGlobalField("channelWidth", channelWidth)
+    setGlobalField("channelHeight", channelHeight)
 end sub
 
-'-----------------------------------------------------------------------------------------------------
-' Safely sets the channelWidth and channelHeight fields on m.global, adding them if they don't exist.
+'---------------------------------------------------------------------------------------------------------
+' Safely sets the value of a field in m.global, adding it explicitly (via addFields) if it doesn't exist.
 '
 ' Params:
-'   * width=1920 as integer - value to use for m.global.channelWidth
-'   * height=1920 as integer - value to use for m.global.channelHeight
-'-----------------------------------------------------------------------------------------------------
-sub ensureGlobalChannelResolutionField(width=1920 as integer, height=1080 as integer)
-    ? "TRUE[X] >>> GlobalUtils::ensureGlobalChannelResolutionField(width=";width;", height=";height;")"
-    if not m.global.HasField("channelWidth") then m.global.AddFields({ channelWidth: width, channelHeight: height })
-    m.global.channelWidth = width
-    m.global.channelHeight = height
-end sub
+'   * fieldName as string - name of the field that will take the fieldValue
+'   * fieldValue as dynamic - value of the global field, use invalid to remove a field
+'---------------------------------------------------------------------------------------------------------
+sub setGlobalField(fieldName as string, fieldValue as dynamic)
+    ? "TRUE[X] >>> GlobalUtils::setGlobalField(fieldName=";fieldName;", fieldValue=";fieldValue;")"
 
-'------------------------------------------------------------------------------
-' Safely sets the streamInfo field on m.global, adding it if it doesn't exist.
-'
-' Params:
-'   * streamInfo="" as string - value to use for m.global.streamInfo
-'------------------------------------------------------------------------------
-sub ensureGlobalStreamInfoField(streamInfo="" as string)
-    ? "TRUE[X] >>> GlobalUtils::ensureGlobalStreamInfoField(streamInfo=";streamInfo;")"
-    if not m.global.HasField("streamInfo") then m.global.AddFields({ streamInfo: streamInfo })
-    m.global.streamInfo = streamInfo
+    if not m.global.hasField(fieldName) then
+        ? "TRUE[X] >>> GlobalUtils::setGlobalField() - adding ";fieldName;" to m.global..."
+        newField = {}
+        newField[fieldName] = fieldValue
+        m.global.addFields(newField)
+    else
+        ? "TRUE[X] >>> GlobalUtils::setGlobalField() - updating existing field (";fieldName;") in m.global..."
+    end if
 end sub


### PR DESCRIPTION
This will allow the credit they earn engaging with ads to be applied to other ad pods. ie Skip Cards will be shown in midrolls if they earn credit in the preroll.