### PR TITLE
Fix (CTV-1745): Stop video stream video player so that ads can buffer videos

### DIFF
--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -228,6 +228,8 @@ sub onTruexAdDataReceived(event as object)
     m.adRenderer.action = tarInitAction
 
     ? "TRUE[X] >>> ContentFlow::onTruexAdDataReceived() - starting TruexAdRenderer..."
+    ' CTV-1745 - must stop the video player since Roku only allows one Video stream to buffer
+    m.videoPlayer.control = "stop"
     m.adRenderer.action = { type: "start" }
     m.adRenderer.focusable = true
     m.adRenderer.SetFocus(true)

--- a/components/MainScene.xml
+++ b/components/MainScene.xml
@@ -27,7 +27,7 @@
         <!-- ***** IMPORTANT ***** -->
         <ComponentLibrary
             id="TruexAdRendererLib"
-            uri="http://s3.amazonaws.com/ctv.truex.com/develop/TruexAdRenderer-Roku-v1.0.2.pkg"/>
+            uri="http://ctv.truex.com/develop/TruexAdRenderer-Roku-v1.0.3.pkg"/>
 
         <!-- Used as parent layout for all Flow's. -->
         <Group

--- a/manifest
+++ b/manifest
@@ -4,7 +4,7 @@
 title=TAR-Roku-Reference
 major_version=1
 minor_version=0
-build_version=0001
+build_version=0002
 ui_resolutions=fhd
 bs_libs_required=roku_ads_lib,googleima3
 supports_input_launch=1


### PR DESCRIPTION
Didn't catch this originally because we had been testing on the Realtor ad, which has no video. This PR makes sure to set the video control to `stop` before starting up the TruexAdRenderer. Tested the midrolls in the reference app 👍 