### PR TITLE
Add deploy make target for Jenkins

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 # Copyright (c) 2019 true[X], Inc. All rights reserved.
 
-APPNAME = TruexReferenceApp
+REFAPPNAME = TruexReferenceApp
 IMPORTS =
 ROKU_TEST_ID = 1
 ROKU_TEST_WAIT_DURATION = 5
@@ -15,8 +15,8 @@ include $(APPSROOT)/app.mk
 
 # deploy `TruexReferenceApp` side-load capable zip file to s3
 # append the major, minor then rc or develop components to the upload path.
-# Note: the MAJOR, MINOR, BUILD_NUM, BUILD_HASH env variables are set upstream by the Jenkins system (TAR's Jenkinsfile)
-deploy: $(APPNAME)
+# Note: the APPNAME, MAJOR, MINOR, BUILD_NUM, BUILD_HASH env variables are set upstream by the Jenkins system (TAR's Jenkinsfile)
+deploy: $(REFAPPNAME)
 	S3_BUCKET=$$(grep s3_bucket ~/Library/Truex/Roku/target | sed 's/s3_bucket=//') ;\
 	echo $$S3_BUCKET ;\
 	echo $$MAJOR ;\
@@ -24,4 +24,4 @@ deploy: $(APPNAME)
 	echo $$BUILD_NUM ;\
 	echo $$BUILD_HASH ;\
 	sed -i "s/ComponentLibrary(\s*)id=\"TruexAdRendererLib\"(\s*)uri=\".*\"/ComponentLibrary(\s*)id=\"TruexAdRendererLib\"(\s*)uri=\"http://@{S3_BUCKET}roku/v${MAJOR}_${MINOR}/${RC_DEVELOP}/${APPNAME}-${RC_DEVELOP}-v${MAJOR}.${MINOR}.${BUILD_NUM}-${BUILD_HASH}.pkg"/g" components/MainScene.xml ;\
-	aws s3 cp dist/apps/${APPNAME}.zip s3://$$S3_BUCKET/roku/v${MAJOR}_${MINOR}/${RC_DEVELOP}/${APPNAME}-${RC_DEVELOP}-v${MAJOR}.${MINOR}.${BUILD_NUM}-${BUILD_HASH}.zip --acl public-read ;\
+	aws s3 cp dist/apps/${REFAPPNAME}.zip s3://$$S3_BUCKET/roku/v${MAJOR}_${MINOR}/${RC_DEVELOP}/${APPNAME}-${RC_DEVELOP}-v${MAJOR}.${MINOR}.${BUILD_NUM}-${BUILD_HASH}.zip --acl public-read ;\

--- a/makefile
+++ b/makefile
@@ -5,7 +5,23 @@ IMPORTS =
 ROKU_TEST_ID = 1
 ROKU_TEST_WAIT_DURATION = 5
 
+# BRANCH_NAME is set by Jenkins. When on a release branch, the following will evaluate to `rc`, while on a develop branch, it will be left alone (`develop`).
+RC_DEVELOP = $(shell echo $$BRANCH_NAME | sed "s/release.*/rc/")
+
 ZIP_EXCLUDE = -x *.sh -x makefile -x dist\* -x *app.mk* -x *README* -x *rokuTarget* -x *.svn* -x *.git* -x *.DS_Store* -x out\* -x packages\* -x design\* -x node_modules/**\* -x node_modules -x .buildpath* -x .project* -x renderer\* -x backup\* -x *.code-workspace
 
 APPSROOT = .
 include $(APPSROOT)/app.mk
+
+# deploy `TruexReferenceApp` side-load capable zip file to s3
+# append the major, minor then rc or develop components to the upload path.
+# Note: the MAJOR, MINOR, BUILD_NUM, BUILD_HASH env variables are set upstream by the Jenkins system (TAR's Jenkinsfile)
+deploy: $(APPNAME)
+	S3_BUCKET=$$(grep s3_bucket ~/Library/Truex/Roku/target | sed 's/s3_bucket=//') ;\
+	echo $$S3_BUCKET ;\
+	echo $$MAJOR ;\
+	echo $$MINOR ;\
+	echo $$BUILD_NUM ;\
+	echo $$BUILD_HASH ;\
+	sed -i "s/ComponentLibrary(\s*)id=\"TruexAdRendererLib\"(\s*)uri=\".*\"/ComponentLibrary(\s*)id=\"TruexAdRendererLib\"(\s*)uri=\"http://@{S3_BUCKET}roku/v${MAJOR}_${MINOR}/${RC_DEVELOP}/${APPNAME}-${RC_DEVELOP}-v${MAJOR}.${MINOR}.${BUILD_NUM}-${BUILD_HASH}.pkg"/g" components/MainScene.xml ;\
+	aws s3 cp dist/apps/${APPNAME}.zip s3://$$S3_BUCKET/roku/v${MAJOR}_${MINOR}/${RC_DEVELOP}/${APPNAME}-${RC_DEVELOP}-v${MAJOR}.${MINOR}.${BUILD_NUM}-${BUILD_HASH}.zip --acl public-read ;\


### PR DESCRIPTION
Updating makefile to support `deploy` target, which updates `MainScene.xml`'s component library URL and publishes the changes to S3.