### PR TITLE
Update TAR pointer to latest release

### DIFF
--- a/components/MainScene.xml
+++ b/components/MainScene.xml
@@ -25,7 +25,7 @@
         See MainScene::init() to get an idea of the library loading process.
         -->
         <!-- ***** IMPORTANT ***** -->
-        <ComponentLibrary id="TruexAdRendererLib" uri="http://ctv.truex.com/develop/TruexAdRenderer-Roku-v1.pkg"/>
+        <ComponentLibrary id="TruexAdRendererLib" uri="http://ctv.truex.com/roku/v1_2/release/TruexAdRenderer-Roku-v1.pkg"/>
 
         <!-- Used as parent layout for all Flow's. -->
         <Group

--- a/components/MainScene.xml
+++ b/components/MainScene.xml
@@ -25,7 +25,7 @@
         See MainScene::init() to get an idea of the library loading process.
         -->
         <!-- ***** IMPORTANT ***** -->
-        <ComponentLibrary id="TruexAdRendererLib" uri="http://ctv.truex.com/roku/v1_2/release/TruexAdRenderer-Roku-v1.pkg"/>
+        <ComponentLibrary id="TruexAdRendererLib" uri="https://ctv.truex.com/roku/v1_2/release/TruexAdRenderer-Roku-v1.pkg"/>
 
         <!-- Used as parent layout for all Flow's. -->
         <Group

--- a/manifest
+++ b/manifest
@@ -3,8 +3,8 @@
 ##   Channel Details
 title=TAR-Roku-Reference
 major_version=1
-minor_version=1
-build_version=0002
+minor_version=2
+build_version=0000
 ui_resolutions=fhd
 bs_libs_required=roku_ads_lib,googleima3
 supports_input_launch=1


### PR DESCRIPTION
I pushed the current RC (v1.2.48-4a5062b) as the first real release here: 
* http://ctv.truex.com/roku/v1_2/release/TruexAdRenderer-Roku-v1.pkg

I updated both reference apps to link to the above package, and pushed those reference apps here too:
* http://ctv.truex.com/roku/v1_2/release/TruexReferenceApp-v1.zip
* http://ctv.truex.com/roku/v1_2/release/TruexRokuReferenceApp-v1.zip

I tested that both apps work with sideloading. 

Finally I updated the links in the integration blurbs in the google doc: 
* https://docs.google.com/document/d/1Ie-URXB75kUFc_plaJA5QjCAtwEwC71dcqZWwblyRC8/edit?usp=sharing

