### PR TITLE
CTV-3609 | Google reference app seek cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.3.0
+* Fixed a bug that caused seek to be 1 second more than needed after playback resume from ad.
+* Fixed a bug that caused seek to occur twice when resuming content playback from ad.
+
 ## v1.1.2
 * Updated to v1 of the TruexAdRenderer (will automatically pick up minor updates from then on)
 

--- a/components/ContentFlow.brs
+++ b/components/ContentFlow.brs
@@ -202,8 +202,7 @@ sub onTruexAdDataReceived(event as object)
     m.videoPlayer.control = "pause"
     m.videoPositionAtAdBreakPause = m.videoPlayer.position
     m.currentAdBreak = decodedData.currentAdBreak
-    ' TODO: for some reason the video only seeks when we add a literal value (+ 1)
-    m.streamSeekDuration = decodedData.truexAdDuration + 1
+    m.streamSeekDuration = decodedData.truexAdDuration
 
     '
     ' [5]
@@ -347,7 +346,6 @@ sub resumeVideoStream()
     if m.videoPlayer <> invalid then
         m.videoPlayer.SetFocus(true)
         m.videoPlayer.control = "play"
-        m.videoPlayer.seek = m.videoPositionAtAdBreakPause + m.streamSeekDuration
         ' Add 1 second to avoid resuming too early, potentially due to rounding issues
         m.videoPlayer.seek = m.videoPositionAtAdBreakPause + m.streamSeekDuration + 1 
     end if

--- a/manifest
+++ b/manifest
@@ -3,8 +3,8 @@
 ##   Channel Details
 title=TAR-Roku-Reference
 major_version=1
-minor_version=2
-build_version=0001
+minor_version=3
+build_version=0000
 ui_resolutions=fhd
 bs_libs_required=roku_ads_lib,googleima3
 supports_input_launch=1


### PR DESCRIPTION
* Removal of extra instance of `+ 1` for the streamSeekDuration in onTruexAdDataReceived()
* removal of extra instance of seeking in resumeVideoStream()